### PR TITLE
Fix curse/bless button layout in Safari

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -62,18 +62,21 @@
     outline:                    none;
 
     display:                    -webkit-flex;
-    -webkit-flex-direction:     column;
+    -webkit-flex-direction:     row;
     -webkit-justify-content:    center;
 
     display:                    flex;
-    flex-direction:             column;
+    flex-direction:             row;
     justify-content:            center;
+
 }
 
 .icon-text
 {
-    width:                      100%;
+    width:                      32%;
+    height:                     100%;
     text-align:                 center;
+    margin:                     0;
 
     color:                      white;
     text-shadow:
@@ -84,6 +87,7 @@
 
     font-family:                'Nyala', 'Sakkal Majalla', 'Philosopher', sans-serif;
     font-size:                  150%;
+    line-height:                1.5;
 }
 
 .counter-icon .background
@@ -120,26 +124,18 @@
 
 .counter-icon .button
 {
-    position:                   absolute;
-    width:                      35%;
+    width:                      33%;
     height:                     100%;
+    margin:                     0;
 
     font-family:                Helvetica, Arial, sans-serif;
     font-weight:                bold;
-    font-size:                  250%;
+    font-size:                  180%;
     text-shadow:
         -1px -1px 0 #fff,
         1px -1px 0 #fff,
         -1px 1px 0 #fff,
         1px 1px 0 #fff;
-
-    display:                    -webkit-flex;
-    -webkit-flex-direction:     column;
-    -webkit-justify-content:    center;
-
-    display:                    flex;
-    flex-direction:             column;
-    justify-content:            center;
 
   -webkit-touch-callout:        none; /* iOS Safari */
     -webkit-user-select:        none; /* Safari */
@@ -153,13 +149,11 @@
 
 .increment.button
 {
-    right:                      0;
     color:                      #080;
 }
 
 .decrement.button
 {
-    left:                       0;
     color:                      #800;
 }
 

--- a/logic.js
+++ b/logic.js
@@ -611,14 +611,14 @@ function add_modifier_deck(container, deck)
 {
     function create_counter(card_type, increment_func, decrement_func)
     {
-        function create_button(class_name, text, func, text_span)
+        function create_button(class_name, text, func, text_element)
         {
             var button = document.createElement("div");
             button.className = class_name + " button";
             button.innerText = text;
 
             button.onclick = function() {
-                text_span.innerText = func(card_type);
+                text_element.innerText = func(card_type);
             };
 
             return button;
@@ -631,19 +631,19 @@ function add_modifier_deck(container, deck)
         background.className = "background " + card_type;
         widget_container.appendChild(background);
 
-        var text_span = document.createElement("span");
-        text_span.className = "icon-text";
-        text_span.innerText = "0";
-        widget_container.appendChild(text_span);
+        var text_element = document.createElement("div");
+        text_element.className = "icon-text";
+        text_element.innerText = "0";
 
-        widget_container.appendChild(create_button("increment", "+", increment_func, text_span));
-        widget_container.appendChild(create_button("decrement", "-", decrement_func, text_span));
+        widget_container.appendChild(create_button("decrement", "-", decrement_func, text_element));
+        widget_container.appendChild(text_element);
+        widget_container.appendChild(create_button("increment", "+", increment_func, text_element));
 
         document.body.addEventListener(EVENT_NAMES.MODIFIER_CARD_DRAWN, function(e)
         {
             if (e.detail.card_type === card_type)
             {
-                text_span.innerText = e.detail.count;
+                text_element.innerText = e.detail.count;
             }
         });
 


### PR DESCRIPTION
@GinoGalotti This should fix the Safari issues with the curse/bless icons. It isn't cross-browser pixel-perfect, but it's close enough to be usable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ginogalotti/gloomycompanion/4)
<!-- Reviewable:end -->
